### PR TITLE
Fix xhost call for cuda_runtime

### DIFF
--- a/images/cuda_runtime/Makefile
+++ b/images/cuda_runtime/Makefile
@@ -9,8 +9,9 @@ OPTS=/sbin/my_init --skip-startup-files --quiet --skip-runit
 
 check: $(TS)
 	### [ -z "${DISPLAY}" ] && exit 1
-	xhost + || exit 1
+	xhost +si:localuser:root || exit 1
 	docker ps -a
 	nvidia-docker run --rm -e DISPLAY ${RUNTERM} --label is_top_app=1 -v /tmp/:/tmp/:rw $(IMG) ${OPTS} -- ${CMD}
+	xhost -si:localuser:root || exit 1
 
 build: build_full


### PR DESCRIPTION
We don't want remote or other local users to control our X server input
(password entry, ...), so only permit root (could also use xauth
cookies, but that's more hazzle).

Note that this issue is also present with other images (`grep 'xhost' images/ -r`), but I didn't mess with them, so no fix included for them here.