### PR TITLE
Build kivy image with pip

### DIFF
--- a/images/kivy/Dockerfile
+++ b/images/kivy/Dockerfile
@@ -1,28 +1,30 @@
 FROM hilbert/gui
 
-MAINTAINER Oleksandr Motsak <malex984+hilbert.kivy@gmail.com>
+LABEL maintainer "Volker Gaibler <volker.gaibler@h-its.org>"
 
 # http://kivy.org/docs/installation/installation-linux.html#ubuntu-11-10-or-newer
+ENV DEBIAN_FRONTEND noninteractive
 
-RUN DEBIAN_FRONTEND=noninteractive apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A863D2D6 && \
-    DEBIAN_FRONTEND=noninteractive echo|add-apt-repository ppa:kivy-team/kivy && \
-    update.sh && install.sh python-kivy python-numpy && clean.sh
-# TODO: python3?
+RUN apt-get -qy update \
+    && apt-get -qy install python-pip python3-pip build-essential git python python-dev \
+            python3 python3-dev libav-tools libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev \
+            libsdl2-ttf-dev libportmidi-dev libswscale-dev libavformat-dev libavcodec-dev \
+            zlib1g-dev libgstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good
 
+# setup virtual environments available to users
+COPY setup-venv.sh /opt/kivy/
+RUN pip2 install --upgrade pip virtualenv setuptools \
+    && pip3 install --upgrade pip virtualenv setuptools \
+    && cd /opt/kivy/ && ./setup-venv.sh
+
+# default system-wide (if no virtual environments used)
+RUN pip2 install Cython==0.23 \
+    && pip2 install kivy==1.9.1 \
+    && pip2 install numpy==1.13.3
+
+# test application
 RUN git clone https://github.com/stocyr/Deflectouch.git /usr/local/src/Deflectouch/
 COPY run.sh /usr/local/src/Deflectouch/
-
-## http://kivy.org/docs/api-kivy.input.providers.probesysfs.html#module-kivy.input.providers.probesysfs
-## http://kivy.org/docs/api-kivy.input.providers.mtdev.html
-## https://wiki.ubuntu.com/Multitouch
-## https://launchpad.net/canonical-multitouch
-
-# RUN update.sh && install.sh alsamixergui pulseaudio && clean.sh
-
-# WORKDIR /usr/local/src/Deflectouch/
-
-
-
 
 ARG IMAGE_VERSION=latest
 ARG GIT_NOT_CLEAN_CHECK
@@ -44,7 +46,7 @@ LABEL org.label-schema.description="may be used as a base for all kivy-related i
       org.label-schema.vendor="IMAGINARY gGmbH" \
       org.label-schema.url="https://hilbert.github.io" \
       org.label-schema.schema-version="1.0" \
-      com.microscaling.license="Apache-2.0"     
+      com.microscaling.license="Apache-2.0"
 
 ONBUILD LABEL org.label-schema.build-date="" \
       org.label-schema.name="" \
@@ -60,3 +62,5 @@ ONBUILD LABEL org.label-schema.build-date="" \
       IMAGE_VERSION="" \
       GIT_NOT_CLEAN_CHECK=""
 
+
+CMD ["/bin/bash"]

--- a/images/kivy/setup-venv.sh
+++ b/images/kivy/setup-venv.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Install kivy into virtual environments
+# Volker Gaibler, 2017
+#
+# module combinations
+# https://kivy.org/docs/installation/installation-linux.html#ubuntu-11-10-or-newer#common-dependencies
+# [note: numpy is not a dependency, only added because install may be slow]
+#
+# use them as always, e.g. for the python2 version of kivy 1.9.1 call
+# . /opt/kivy/venv/py2-1.9.1
+
+
+# setup virtual environments under this directory: can be activated at user's convenience
+prefix=/opt/kivy/venv
+
+setup_venv () {
+    (
+    # versions as parameters:
+    local v=$1  # python
+    local k=$2  # kivy
+    local c=$3  # cython
+    local n=$4  # numpy
+
+    local dir="$prefix/py$v-$k"
+    echo "##################### Setting up new virtual environment: #####################"
+    echo "  dir=$dir"
+    echo "  kivy=$k"
+    echo "  cython=$c"
+    echo "  numpy=$n"
+
+    virtualenv -p /usr/bin/python$v $dir
+    source $dir/bin/activate
+    pip$v install Cython==$c
+    pip$v install kivy==$k
+    pip$v install numpy==$n
+    deactivate
+    )
+}
+
+
+mkdir -p $prefix
+
+# python/pip versions
+for v in 2 3 ; do
+
+    # tested version combinations:
+    #          python  kivy    cython  numpy
+    setup_venv $v      1.8.0   0.20.2  1.13.3
+    setup_venv $v      1.9.1   0.23    1.13.3
+    setup_venv $v      1.10.0  0.25.2  1.13.3
+
+done


### PR DESCRIPTION
Virtual environments provided for different versions of kivy and python
under /opt/kivy/venv. Created by setup-venv.sh script.

I haven't purged the ubuntu packages that were used for building because this allows the user to add more versions in a easy way. Feel free to say that you don't like this...

Volker