### PR TITLE
Kiosk: Don't preload the heartbeat library on failed page load

### DIFF
--- a/images/kiosk/hb_preload.sh
+++ b/images/kiosk/hb_preload.sh
@@ -54,6 +54,10 @@ cat << EOF > ${PRELOAD_FILE}
     // wait for the document finish loading and ...
     var webContents = require('electron').remote.getCurrentWindow().webContents;
     webContents.on('did-finish-load',() => {
+        // don't load the library on failed page load
+        if(window.location.href=="data:text/html,chromewebdata")
+            return;
+
         // ... define the heartbeat configuration
         const heartbeatCfg = {
             url: Heartbeat.getPassedUrl('${HB_URL}'),


### PR DESCRIPTION
If `location.href` points to Chrome's default error page `data:text/html,chromewebdata`, the library is not loaded. This solution may not be optimal, but there doesn't seem to be a better way to check for such errors in a preload script.